### PR TITLE
fix: SAPI client set runId

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -85,10 +85,13 @@ class Component extends BaseComponent
 
     private function initSapi(): StorageApi
     {
-        return new StorageApi([
+        $storageApi = new StorageApi([
             'url' => getenv('KBC_URL'),
             'token' => getenv('KBC_TOKEN'),
         ]);
+
+        $storageApi->setRunId(getenv('KBC_RUNID'));
+        return $storageApi;
     }
 
     private function initS3(string $region): S3Client


### PR DESCRIPTION
Fix set SapiClient runId from ENV variable https://github.com/keboola/app-project-restore/issues/10