### PR TITLE
Test data cleanup fix

### DIFF
--- a/aws-tests-cf-template.json
+++ b/aws-tests-cf-template.json
@@ -30,7 +30,8 @@
                   "Action": [
                     "s3:ListBucket",
                     "s3:GetObject",
-                    "s3:PutObject"
+                    "s3:PutObject",
+                    "s3:DeleteObject"
                   ],
                   "Effect": "Allow",
                   "Resource": [

--- a/tests/phpunit/FunctionalTest.php
+++ b/tests/phpunit/FunctionalTest.php
@@ -120,7 +120,7 @@ class FunctionalTest extends TestCase
 
     public function testRestoreObsoleteConfigs(): void
     {
-        $this->createConfigFile('configurations-obsolete');
+        $this->createConfigFile('configurations-skip');
 
         $runProcess = $this->createTestProcess();
         $runProcess->mustRun();
@@ -138,7 +138,7 @@ class FunctionalTest extends TestCase
 
     public function testRestoreConfigsAppNotify(): void
     {
-        $this->createConfigFile('configurations-obsolete');
+        $this->createConfigFile('configurations-skip');
 
         $runProcess = $this->createTestProcess();
         $runProcess->mustRun();


### PR DESCRIPTION
Fixes:
- CloudFormation stack template - added permissions for delete objects from S3 (needed for test data cleanup)
- loadToS3 script - bucket cleanup with test for still existing objects
- fixed testRestoreObsoleteConfigs and testRestoreConfigsAppNotify