### PR TITLE
[AJDA-1274] update keboola/kbc-project-restore -  reduce metadata batch size from 100 to 50

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1329,16 +1329,16 @@
         },
         {
             "name": "keboola/kbc-project-restore",
-            "version": "2.28.0",
+            "version": "2.28.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/keboola/php-kbc-project-restore.git",
-                "reference": "be512ae8225c9e9b17bbe08ba0369a66818f554d"
+                "reference": "bc1018cb4917d736bf9733e2fe47b4a8455fee06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/keboola/php-kbc-project-restore/zipball/be512ae8225c9e9b17bbe08ba0369a66818f554d",
-                "reference": "be512ae8225c9e9b17bbe08ba0369a66818f554d",
+                "url": "https://api.github.com/repos/keboola/php-kbc-project-restore/zipball/bc1018cb4917d736bf9733e2fe47b4a8455fee06",
+                "reference": "bc1018cb4917d736bf9733e2fe47b4a8455fee06",
                 "shasum": ""
             },
             "require": {
@@ -1376,9 +1376,9 @@
             ],
             "description": "Restore KBC project",
             "support": {
-                "source": "https://github.com/keboola/php-kbc-project-restore/tree/2.28.0"
+                "source": "https://github.com/keboola/php-kbc-project-restore/tree/2.28.1"
             },
-            "time": "2025-11-03T22:29:15+00:00"
+            "time": "2025-11-04T14:44:21+00:00"
         },
         {
             "name": "keboola/notification-api-php-client",


### PR DESCRIPTION
Follow up https://linear.app/keboola/issue/AJDA-1274/project-migrations-restore-table-metadata-split-to-chunks


----

## Release Notes

  - Updates core project restore library to fix an issue with restoring table and column metadata for tables having hundreds of columns. Metadata is now restored gradually in small chunks with 50 columns

  ## Change Type

  Fix

  ## Impact Analysis

  - **Who's affected:** Teams migrating Keboola projects across different cloud regions

  ## Customer Communication Plans

  No customer-facing communication needed. This is an internal library update that enhances existing migration functionality without changing user-facing behavior or requiring action from customers.

  ## Deployment Plan

Merge and release a new version of component.

  ## Rollback Plan

Fix dependencies to previous version  of `keboola/kbc-project-restore` and release as a new version


  ## Post-Release Support Plan
N/A
