### PR TITLE
[AJDA-2577] Add architectural documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,116 @@
+# app-project-restore – AI Development Context
+
+## What this repository does
+
+Keboola App component for restoring a project from a backup in cloud storage (S3, ABS, GCS). Wraps the `php-kbc-project-restore` library. Run by `app-project-migrate` as Phase 3 of the pipeline, but can also be run standalone.
+
+## Documentation
+
+- **`docs/overview.md`** – restore sequence, skipped components, parallel table creation
+- **`docs/how-it-works.md`** – step-by-step restore flow (checkEmptyProject, 3 phases of restoreTables, why aliases come after tables)
+- **`docs/configuration.md`** – complete input parameter reference for all 3 backends
+
+## Required environment variables
+
+Before running tests, verify that these variables are present in `.env` (or exported in the shell). If missing, ask for them explicitly.
+
+**For AWS S3 tests:**
+
+| Variable | Description |
+|---|---|
+| `TEST_STORAGE_API_URL` | Keboola project URL (destination) |
+| `TEST_STORAGE_API_TOKEN` | Project storage token (destination) |
+| `TEST_AWS_ACCESS_KEY_ID` | AWS Access Key ID |
+| `TEST_AWS_SECRET_ACCESS_KEY` | AWS Secret Access Key |
+| `TEST_AWS_REGION` | AWS region (e.g. `us-east-1`) |
+| `TEST_AWS_S3_BUCKET` | S3 bucket name containing the backup |
+
+**For Azure ABS tests:**
+
+| Variable | Description |
+|---|---|
+| `TEST_AZURE_ACCOUNT_NAME` | Azure storage account name |
+| `TEST_AZURE_ACCOUNT_KEY` | Azure storage key |
+| `TEST_AZURE_CONTAINER_NAME` | Azure Blob Storage container name containing the backup |
+
+**For GCS tests:**
+
+| Variable | Description |
+|---|---|
+| `TEST_GCP_SERVICE_ACCOUNT` | JSON service account key (full JSON as string) |
+| `TEST_GCP_BUCKET` | GCS bucket name containing the backup |
+
+**For functional tests:**
+
+| Variable | Description |
+|---|---|
+| `TEST_COMPONENT_ID` | Component ID used in datadir tests |
+
+**Platform-injected (automatically set by Keboola Runner when running in Keboola):**
+
+| Variable | Description |
+|---|---|
+| `KBC_RUNID` | Job run ID, set on the SAPI client |
+| `KBC_COMPONENTID` | Current component ID – used in `validateProject()` to allow self-configuration in an otherwise empty project |
+| `KBC_CONFIGID` | Current configuration ID – see above |
+
+> Check that the `.env` file exists in the repo root. If not, create it based on the list above.
+
+## Development commands
+
+Service name in `docker-compose.yml` is `dev`. The `composer tests` script runs `tests-prepare-s3` + `tests-prepare-abs` + `tests-prepare-gcs` + `tests-phpunit` in sequence.
+
+```bash
+docker compose run --rm dev composer phpcs
+docker compose run --rm dev composer phpstan
+docker compose run --rm dev composer tests           # prepare + phpunit
+docker compose run --rm dev composer tests-phpunit   # phpunit only without data preparation
+docker compose run --rm dev composer tests-prepare-s3    # S3 data preparation only
+docker compose run --rm dev composer tests-prepare-abs   # ABS data preparation only
+docker compose run --rm dev composer tests-prepare-gcs   # GCS data preparation only
+```
+
+## Key files
+
+| File | Purpose |
+|---|---|
+| `src/Component.php` | Entry point |
+| `src/Application.php` | Restore orchestration |
+| `src/Config.php` | Configuration getters |
+| `src/ConfigDefinition.php` | Parameter validation |
+| `src/S3UriParser.php` | S3 URI parser (`s3://bucket/path` → bucket + key) |
+| `src/Storages/` | Adapters for S3, ABS, GCS |
+
+## Important constants in Application.php
+
+**COMPONENTS_WITH_CUSTOM_RESTORE** – components skipped during `restoreConfigs()`:
+```
+orchestrator, gooddata-writer,
+keboola.wr-db-snowflake, keboola.wr-snowflake-blob-storage,
+keboola.wr-db-snowflake-gcs, keboola.wr-db-snowflake-gcs-s3
+```
+
+**IGNORED_CHECK_COMPONENTS** – ignored during `checkEmptyProject()`:
+```
+keboola.app-project-migrate-large-tables, keboola.app-project-migrate, keboola.orchestrator
+```
+
+## Orchestrator
+
+Orchestrator configurations are restored but with `isDisabled: true`. Users must manually re-enable after verifying the migration.
+
+## Parallel table creation
+
+Tables are created via child processes (`worker-create-table.php`). Number of processes: `tableParallelism` (default 10).
+
+## Coding standards
+
+- PHP 8.x with strict types
+- PHPStan level max
+- Keboola coding standard (PSR-12)
+
+## Related repositories
+
+- Library: `php-kbc-project-restore`
+- Orchestrator: `app-project-migrate`
+- Paired with: `app-project-backup`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ Before running tests, verify that these variables are present in `.env` (or expo
 
 ## Development commands
 
-Service name in `docker-compose.yml` is `dev`. The `composer tests` script runs `tests-prepare-s3` + `tests-prepare-abs` + `tests-prepare-gcs` + `tests-phpunit` in sequence.
+Service name in `docker-compose.yml` is `dev`. The `composer tests` script runs `tests-prepare-abs` + `tests-prepare-s3` + `tests-prepare-gcs` + `tests-phpunit` in sequence.
 
 ```bash
 docker compose run --rm dev composer phpcs

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,132 @@
+# Configuration parameter reference – app-project-restore
+
+## Restore switches
+
+Default value is `true` unless stated otherwise.
+
+| Parameter | Default | Description |
+|---|---|---|
+| `restoreProjectMetadata` | `true` | Restores default branch metadata |
+| `restoreConfigs` | `true` | Restores component configurations |
+| `restoreBuckets` | `true` | Creates storage buckets |
+| `restoreTables` | `true` | Creates table structures. **Note:** condition is `restoreBuckets && restoreTables` – if `restoreBuckets: false`, tables will not be restored even if `restoreTables: true` |
+| `restorePermanentFiles` | `true` | Restores permanent files |
+| `restoreTriggers` | `true` | Restores flow triggers |
+| `restoreNotifications` | `true` | Restores notification subscriptions |
+
+## Restore options
+
+| Parameter | Default | Description |
+|---|---|---|
+| `dryRun` | `false` | Simulation without actual changes |
+| `forcePrimaryKeyNotNull` | `false` | Forces NOT NULL on PK columns in typed tables (resolves issues when migrating between backends) |
+| `tableParallelism` | `10` | Number of parallel worker processes for table creation |
+| `useDefaultBackend` | `false` | Ignores storage backend from backup, uses destination project's default backend |
+| `checkEmptyProject` | `true` | Refuses restore if destination project is not empty |
+
+## S3 credentials
+
+Used if the backup is on S3.
+
+| Parameter | Required | Description |
+|---|---|---|
+| `s3.backupUri` | ✓ | Full S3 URI of the backup (e.g. `s3://bucket/path/to/backup`) |
+| `s3.accessKeyId` | ✓ | AWS Access Key ID |
+| `s3.#secretAccessKey` | ✓ | AWS Secret Access Key |
+| `s3.#sessionToken` | ✓ | Session token (typically from `generate-read-credentials` – temporary STS credentials) |
+
+## ABS credentials (Azure Blob Storage)
+
+Used if the backup is on ABS.
+
+| Parameter | Required | Description |
+|---|---|---|
+| `abs.container` | ✓ | Azure Blob Storage container name |
+| `abs.#connectionString` | ✓ | Azure connection string |
+
+## GCS credentials (Google Cloud Storage)
+
+Used if the backup is on GCS.
+
+| Parameter | Required | Description |
+|---|---|---|
+| `gcs.backupUri` | ✓ | Full GCS URI of the backup (e.g. `gs://bucket/path/to/backup`) |
+| `gcs.bucket` | ✓ | GCS bucket name |
+| `gcs.projectId` | ✓ | Google Cloud project ID |
+| `gcs.credentials.#accessToken` | ✓ | Access token (temporary, from `generate-read-credentials`) |
+| `gcs.credentials.expiresIn` | ✓ | Token expiry time |
+| `gcs.credentials.tokenType` | ✓ | Token type (e.g. `Bearer`) |
+
+> Exactly one backend (s3, abs, or gcs) must always be configured.
+
+## Configuration examples
+
+### Full restore from S3
+
+S3 credentials are typically temporary STS credentials from `generate-read-credentials` (all 3 parameters including `#sessionToken` are required):
+
+```json
+{
+  "parameters": {
+    "s3": {
+      "backupUri": "s3://my-kbc-backups/12345",
+      "accessKeyId": "ASIA...",
+      "#secretAccessKey": "secret",
+      "#sessionToken": "FwoGZXIvYXdzE..."
+    }
+  }
+}
+```
+
+### Restore from S3 (configurations only, no tables or files)
+
+```json
+{
+  "parameters": {
+    "s3": {
+      "backupUri": "s3://my-kbc-backups/12345",
+      "accessKeyId": "ASIA...",
+      "#secretAccessKey": "secret",
+      "#sessionToken": "FwoGZXIvYXdzE..."
+    },
+    "restoreTables": false,
+    "restorePermanentFiles": false
+  }
+}
+```
+
+### Restore from GCS with temporary credentials
+
+```json
+{
+  "parameters": {
+    "gcs": {
+      "backupUri": "gs://my-kbc-backups/12345",
+      "bucket": "my-kbc-backups",
+      "projectId": "my-gcp-project",
+      "credentials": {
+        "#accessToken": "ya29...",
+        "expiresIn": "3600",
+        "tokenType": "Bearer"
+      }
+    },
+    "tableParallelism": 20
+  }
+}
+```
+
+### Dry run (simulation without changes)
+
+```json
+{
+  "parameters": {
+    "s3": {
+      "backupUri": "s3://my-kbc-backups/12345",
+      "accessKeyId": "AKIA...",
+      "#secretAccessKey": "secret",
+      "#sessionToken": "FwoGZXIvYXdzE..."
+    },
+    "dryRun": true
+  }
+}
+```

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -1,0 +1,164 @@
+# app-project-restore – how the restore works
+
+## Call flow (Application::run)
+
+```
+Component.php
+  └─ Application::run()
+       1. initSapi()
+       2. (if checkEmptyProject) validateProject()
+       3. storageBackend->getRestore()  → S3Restore / AbsRestore / GcsRestore
+       4. (if dryRun) restore->setDryRunMode()
+       5. restore->setForcePrimaryKeyNotNull()
+       6. Restore sequence (each step can be disabled):
+            restoreProjectMetadata()
+            restoreBuckets(!useDefaultBackend)
+            restoreConfigs(COMPONENTS_WITH_CUSTOM_RESTORE)
+            restoreTables(tableParallelism)
+            restoreTableAliases()
+            restoreTriggers()
+            restoreNotifications()
+            restorePermanentFiles()
+       7. Warnings for skipped components (orchestrator, gooddata, snowflake writers)
+```
+
+## Step 1: checkEmptyProject
+
+Before restoring, verifies that the destination project is empty:
+
+```
+listBuckets()  →  if buckets exist → UserException
+
+listComponents() filtered:
+  - keboola.app-project-migrate-large-tables  (ignored)
+  - keboola.app-project-migrate               (ignored)
+  - keboola.orchestrator                      (ignored)
+  - current component's own configuration     (ignored)
+
+if other configurations remain → UserException
+```
+
+Ignored components are part of the migration process and may be present in the destination project without meaning that the project is non-empty.
+
+## Step 2: restoreProjectMetadata
+
+Restores default branch metadata from `defaultBranchMetadata.json`.
+
+```
+getDataFromStorage('defaultBranchMetadata.json')
+DevBranchesMetadata::addBranchMetadata(metadata)
+```
+
+## Step 3: restoreBuckets
+
+```
+getDataFromStorage('buckets.json') → list of buckets
+
+if checkBackend:
+  – verifies the project has the required backend (MySQL/Redshift/Snowflake)
+
+forEach bucket:
+  – skips sys buckets (name does not start with 'c-')
+  – skips linked buckets
+  – createBucket(name, stage, description, backend)
+  – postBucketMetadata(metadata)
+```
+
+`useDefaultBackend: true` → `backend` from backup is ignored, the project's default backend is used.
+
+## Step 4: restoreConfigs
+
+`Application.php` only calls `$restore->restoreConfigs(COMPONENTS_WITH_CUSTOM_RESTORE)`. The actual logic (reading `configurations.json` from storage, creating configurations in SAPI) is implemented in `php-kbc-project-restore/Restore.php`.
+
+Skips components in `COMPONENTS_WITH_CUSTOM_RESTORE`:
+- `orchestrator`, `gooddata-writer`
+- `keboola.wr-db-snowflake`, `keboola.wr-snowflake-blob-storage`
+- `keboola.wr-db-snowflake-gcs`, `keboola.wr-db-snowflake-gcs-s3`
+
+For each other configuration:
+```
+addConfiguration()     – empty configuration with ID
+  if orchestrator:     isDisabled = true  ← important!
+updateConfiguration()  – fills data, ConfigurationCorrector translates component IDs
+updateConfigurationState()
+forEach row:
+  addConfigurationRow() + updateConfigurationRow() + updateConfigurationRowState()
+(if rowsSortOrder) updateConfiguration() – sets row order
+(if .json.metadata) addConfigurationMetadata()
+```
+
+### Why orchestrator is disabled
+
+`keboola.orchestrator` configurations are restored with `isDisabled: true`. Otherwise, orchestrations could automatically start in the destination project before all data and configurations are properly set up. Users must manually re-enable orchestrations after verifying the migration.
+
+### ConfigurationCorrector
+
+When restoring to a different stack, the `componentId` in a configuration may differ (e.g. `keboola.wr-db-snowflake` vs. `keboola.wr-db-snowflake-gcs`). `ConfigurationCorrector` translates IDs via `StackSpecificComponentIdTranslator`.
+
+## Step 5: restoreTables – 3 phases
+
+### Phase 1: Prepare work items
+
+```
+getDataFromStorage('tables.json')
+forEach table:
+  – skips alias tables
+  – skips tables whose bucket does not exist
+  – builds workerInput: sapiUrl, sapiToken, bucketId, tableName, columns, primaryKey, isTyped, ...
+```
+
+### Phase 2: Parallel table creation (worker processes)
+
+```
+interleaveByBucket(workItems)
+  → interleaving: tables from different buckets alternate
+  → reason: Snowflake does not handle parallel operations well on the same bucket
+
+createTablesParallel(workItems, parallelism=10):
+  while pendingItems or runningProcesses:
+    – starts up to `parallelism` processes (worker-create-table.php)
+    – each worker receives workerInput via STDIN as JSON
+    – on completion reads JSON output from STDOUT
+    – results: originalTableId → createdTableId mapping
+```
+
+### Why interleaveByBucket
+
+When creating tables in parallel, Snowflake locks metadata at the bucket (schema) level. If multiple workers operated on the same bucket simultaneously, conflicts would occur. Interleaving ensures each worker always operates on a different bucket.
+
+### Phase 3: Sequential data and metadata upload
+
+```
+forEach createdTable:
+  restoreTableColumnsMetadata()  – column-level metadata
+  listTableFiles(tableId)        – finds files in backup storage
+
+  if 1 file without .part_0.csv.gz (non-sliced):
+    uploadFile() + writeTableAsyncDirect()
+
+  if sliced:
+    downloadSlices → uploadSlicedFile(federationToken=true) → writeTableAsyncDirect()
+```
+
+## Step 6: restoreTableAliases
+
+Must run **after** `restoreTables`, because an alias references an already existing table.
+
+```
+forEach alias table (isAlias === true):
+  – verifies the source table exists
+  – verifies the destination bucket exists
+  – createAliasTable(bucketId, sourceTableId, name, aliasOptions)
+  – restoreTableColumnsMetadata()
+```
+
+## Dry-run mode
+
+If `dryRun: true`:
+- No SAPI operations are performed (no `create`, `update`, `upload`)
+- Each skipped operation is logged as `[dry-run] ...`
+- Storage is read normally (to determine what would be restored)
+
+## forcePrimaryKeyNotNull
+
+If a worker returns `isNullablePkError: true`, the table has a nullable PK column. This normally causes an error. With `forcePrimaryKeyNotNull: true`, the column is changed to NOT NULL before setting the PK.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,87 @@
+# app-project-restore – overview
+
+## What the component does
+
+Restores a Keboola project from a backup in cloud storage (S3, ABS or GCS). This is a Keboola App component that wraps the `php-kbc-project-restore` library.
+
+Run by `app-project-migrate` as Phase 3 of the migration pipeline, but can also be run standalone – e.g. for restoring a project from a periodic backup.
+
+## Restore sequence
+
+Steps always run in this order and each can be individually disabled via configuration:
+
+1. `restoreProjectMetadata()` – default branch metadata
+2. `restoreBuckets()` – creates storage buckets
+3. `restoreConfigs(skipComponents)` – all configurations except those with special handling
+4. `restoreTables(parallelism)` – creates table structures (parallel worker processes) – requires both `restoreBuckets: true` AND `restoreTables: true`
+5. `restoreTableAliases()` – alias tables (must come after tables) – runs together with step 4
+6. `restoreTriggers()`
+7. `restoreNotifications()`
+8. `restorePermanentFiles()`
+
+## Skipped components (COMPONENTS_WITH_CUSTOM_RESTORE)
+
+These components are **not restored** by this repository. They require dedicated migration applications:
+
+| Component ID | Who handles it |
+|---|---|
+| `orchestrator` | Orchestrator Migrate App (outside this system) |
+| `gooddata-writer` | GoodData Writer Migrate App (outside this system) |
+| `keboola.wr-db-snowflake` | `app-snowflake-writer-migrate` |
+| `keboola.wr-snowflake-blob-storage` | `app-snowflake-writer-migrate` |
+| `keboola.wr-db-snowflake-gcs` | `app-snowflake-writer-migrate` |
+| `keboola.wr-db-snowflake-gcs-s3` | `app-snowflake-writer-migrate` |
+
+## Orchestrator – special behavior
+
+`keboola.orchestrator` configurations are restored (structure is preserved), but automatically set to `isDisabled: true`. Users must manually re-enable orchestrations after verifying the migration.
+
+## Parallel table creation
+
+Tables are created using `symfony/process` worker scripts (`worker-create-table.php`). The number of parallel processes is determined by `tableParallelism` (default: 10). Work items are interleaved across buckets so parallel workers don't operate on the same bucket simultaneously.
+
+## checkEmptyProject
+
+Before restoring, the component verifies that the destination project is empty. The following are ignored during the check:
+
+```php
+const IGNORED_CHECK_COMPONENTS = [
+    'keboola.app-project-migrate-large-tables',
+    'keboola.app-project-migrate',
+    'keboola.orchestrator',
+];
+```
+
+## Architecture
+
+```
+Component.php
+  └─ Application.php
+       └─ php-kbc-project-restore (library)
+            ├─ S3Restore / AbsRestore / GcsRestore
+            └─ worker-create-table.php (child process, one per table)
+```
+
+## Key files
+
+| File | Description |
+|---|---|
+| `src/Component.php` | Entry point |
+| `src/Application.php` | Restore orchestration |
+| `src/Config.php` | Configuration getters |
+| `src/ConfigDefinition.php` | Parameter validation |
+| `src/Storages/` | Adapters for S3, ABS, GCS |
+
+## Development and testing
+
+```bash
+docker compose run --rm dev composer phpcs
+docker compose run --rm dev composer phpstan
+docker compose run --rm dev composer tests
+```
+
+## Related repositories
+
+- Library: `php-kbc-project-restore`
+- Uses it: `app-project-migrate` (Phase 3)
+- Paired with: `app-project-backup`


### PR DESCRIPTION
Add CLAUDE.md with AI development context, required environment variables, key files and development commands. Add docs/ folder with overview, how-it-works and configuration documentation covering restore sequence, parallel table creation with worker processes, interleaveByBucket logic and all three storage backends (S3, ABS, GCS).